### PR TITLE
#2 save occurred entities

### DIFF
--- a/database/migrations/2020_03_23_211950_alter_mail_log_table_add_occurred_columns.php
+++ b/database/migrations/2020_03_23_211950_alter_mail_log_table_add_occurred_columns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterMailLogTableAddOccurredColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mail_log', function (Blueprint $table) {
+            $table->nullableMorphs('occurred_process');
+            $table->nullableMorphs('occurred_entity');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mail_log', function (Blueprint $table) {
+            $table->dropMorphs('occurred_process');
+            $table->dropMorphs('occurred_entity');
+        });
+    }
+}

--- a/src/Listeners/MailSentListener.php
+++ b/src/Listeners/MailSentListener.php
@@ -57,14 +57,13 @@ class MailSentListener
             $occuredEntity = $event->data[Occurrable::getOccuredEntityKey()] ?? null;
             $occuredProcess = $event->data[Occurrable::getOccuredProcessKey()] ?? null;
 
-            if($occuredEntity && $occuredEntity instanceof Model) {
+            if ($occuredEntity && $occuredEntity instanceof Model) {
                 $log->occurredEntity()->associate($occuredEntity)->save();
             }
 
-            if($occuredProcess && $occuredProcess instanceof Model) {
+            if ($occuredProcess && $occuredProcess instanceof Model) {
                 $log->occurredProcess()->associate($occuredProcess)->save();
             }
-
         } catch (\Throwable $e) {
             Log::debug('Failed to save mail log ['.$e->getMessage().']');
         }

--- a/src/Listeners/MailSentListener.php
+++ b/src/Listeners/MailSentListener.php
@@ -3,6 +3,8 @@
 namespace Giuga\LaravelMailLog\Listeners;
 
 use Giuga\LaravelMailLog\Models\MailLog;
+use Giuga\LaravelMailLog\Traits\Occurrable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Support\Facades\Log;
 
@@ -50,7 +52,19 @@ class MailSentListener
                 'message' => $body,
                 'data' => [],
             ];
-            MailLog::create($data);
+            $log = MailLog::create($data);
+
+            $occuredEntity = $event->data[Occurrable::getOccuredEntityKey()] ?? null;
+            $occuredProcess = $event->data[Occurrable::getOccuredProcessKey()] ?? null;
+
+            if($occuredEntity && $occuredEntity instanceof Model) {
+                $log->occurredEntity()->associate($occuredEntity)->save();
+            }
+
+            if($occuredProcess && $occuredProcess instanceof Model) {
+                $log->occurredProcess()->associate($occuredProcess)->save();
+            }
+
         } catch (\Throwable $e) {
             Log::debug('Failed to save mail log ['.$e->getMessage().']');
         }

--- a/src/Models/MailLog.php
+++ b/src/Models/MailLog.php
@@ -12,12 +12,13 @@ class MailLog extends Model
         'data' => 'array',
     ];
 
-    public function occurredProcess() {
+    public function occurredProcess()
+    {
         return $this->morphTo();
     }
 
-    public function occurredEntity() {
+    public function occurredEntity()
+    {
         return $this->morphTo();
     }
-
 }

--- a/src/Models/MailLog.php
+++ b/src/Models/MailLog.php
@@ -11,4 +11,13 @@ class MailLog extends Model
     protected $casts = [
         'data' => 'array',
     ];
+
+    public function occurredProcess() {
+        return $this->morphTo();
+    }
+
+    public function occurredEntity() {
+        return $this->morphTo();
+    }
+
 }

--- a/src/Traits/Occurrable.php
+++ b/src/Traits/Occurrable.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Giuga\LaravelMailLog\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait Occurrable {
+
+
+
+    public static function getOccuredProcessKey() {
+        return 'event.occurred_process';
+    }
+
+
+
+    public static function getOccuredEntityKey() {
+        return 'event.occurred_entity';
+    }
+
+
+
+    public function occurred(Model $entity = null, Model $process = null) {
+
+        $this->with(static::getOccuredEntityKey(), $entity);
+
+        $this->with(static::getOccuredProcessKey(), $process);
+
+        return $this;
+    }
+
+
+
+}

--- a/src/Traits/Occurrable.php
+++ b/src/Traits/Occurrable.php
@@ -4,31 +4,24 @@ namespace Giuga\LaravelMailLog\Traits;
 
 use Illuminate\Database\Eloquent\Model;
 
-trait Occurrable {
-
-
-
-    public static function getOccuredProcessKey() {
+trait Occurrable
+{
+    public static function getOccuredProcessKey()
+    {
         return 'event.occurred_process';
     }
 
-
-
-    public static function getOccuredEntityKey() {
+    public static function getOccuredEntityKey()
+    {
         return 'event.occurred_entity';
     }
 
-
-
-    public function occurred(Model $entity = null, Model $process = null) {
-
+    public function occurred(Model $entity = null, Model $process = null)
+    {
         $this->with(static::getOccuredEntityKey(), $entity);
 
         $this->with(static::getOccuredProcessKey(), $process);
 
         return $this;
     }
-
-
-
 }


### PR DESCRIPTION
Added 2 polymorphic relations to `mail_log` table.

- `occurredProcess` - parent entity consisting of small entities, example, order and other long processing pipelines.

- `occurredEntity` - child entity, example, payment of order, delivery of order, refund of order, etc.

Usage:


1) `php artisan migrate`

2) add `Occurrable` trait to your `Mailable` mails

```php
use Giuga\LaravelMailLog\Traits\Occurrable;
```

3) Bind entities on mail send;

```php
$mail->occurred($payment);
```
or
```php
$mail->occurred($payment, $order);
```
or
```php
$mail->occurred(null, $order);
```
and send
```php
Mail::to($contacts)->send($mail);
```