### PR TITLE
Fix: laravel 8 not firing the events

### DIFF
--- a/src/MailEventServiceProvider.php
+++ b/src/MailEventServiceProvider.php
@@ -27,5 +27,7 @@ class MailEventServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // Laravel 8 need to invoke this to register the events defined at $listen
+        parent::register();
     }
 }


### PR DESCRIPTION
laravel 8 require register() method to call parent::register() method for registering events defined at $listen